### PR TITLE
add process p8_ee_WW_mumu_ecm240 to param_FCCee.py

### DIFF
--- a/config/param_FCCee.py
+++ b/config/param_FCCee.py
@@ -47,7 +47,7 @@ pythiacards_dir  = "/eos/experiment/fcc/ee/generation/FCC-config/_VERSION_/FCCee
 evtgencards_dir  = "/eos/experiment/fcc/ee/generation/FCC-config/_VERSION_/FCCee/Generator/EvtGen/"
 # /cvmfs/fcc.cern.ch/sw/latest/setup.sh 
 ##delphes base card detector
-detectors = ['IDEA']
+detectors = ['IDEA','IDEA_3T']
 
 
 


### PR DESCRIPTION
The card includes W -> mu and W -> tau -> mu. The cross-section was determined from the Pythia8 WW cross-section and using BR(W ->mu) = BR(W -> tau) = 0.1067 and BR(tau ->mu) = 0.1739.