### PR TITLE
Prep winter2023

### DIFF
--- a/bin/run.py
+++ b/bin/run.py
@@ -143,10 +143,23 @@ if __name__=="__main__":
         statfile=para.lhe_stat
 
     elif args.STDHEP:
-        indir=para.stdhep_dir
         fext=para.stdhep_ext
-        yamldir=para.yamldir+'stdhep/'
+        aprodtag = version.replace("_training","")
+        yamldir=para.yamldir+'stdhep/'+aprodtag+'/'
+        indir=para.stdhep_dir+'/'+aprodtag+'/'
+        if training:
+            yamldir=para.yamldir+'stdhep/'+aprodtag+'/training/'
+            indir=para.stdhep_dir+aprodtag+'/training/'
+        if 'spring2021' in version or 'pre_fall2022' in version or 'dev' in version : # for proTags older than winter2023
+            indir=para.stdhep_dir
+            yamldir=para.yamldir+'stdhep/'
+            if training:
+                yamldir=para.yamldir+'stdhep/training/'
+                indir=para.stdhep_dir+'/training/'
         statfile=para.stdhep_stat
+        print("yamldir = ",yamldir)
+        print("indir =",indir)
+
 
     elif args.reco:
         indir='%s%s/%s'%(para.delphes_dir,version,detector)

--- a/bin/send_fromstdhep.py
+++ b/bin/send_fromstdhep.py
@@ -130,7 +130,18 @@ class send_fromstdhep():
             if not ut.dir_exist(yamldir):
                 os.system("mkdir -p %s"%yamldir)
 
+
+        training=False
+        if 'training' in self.version: training=True
+
         yamlstdhepdir = '%s/stdhep/%s'%(self.para.yamldir,self.process)
+        if training:
+            yamlstdhepdir = '%s/stdhep/training/%s'%(self.para.yamldir,self.process)
+        if not( 'spring2021' in self.version or 'pre_fall2022' in self.version or 'dev' in self.version ):   # winter2023 and later:
+            prodtag = self.version.replace("_training","")
+            yamlstdhepdir = '%s/stdhep/%s/%s'%(self.para.yamldir,prodtag,self.process)
+            if training:
+                 yamlstdhepdir = '%s/stdhep/%s/training/%s'%(self.para.yamldir,prodtag,self.process)
         print("yamlstdhepdir = ",yamlstdhepdir)
   
         All_files = glob.glob("%s/events_*.yaml"%yamlstdhepdir)

--- a/bin/send_stdhep.py
+++ b/bin/send_stdhep.py
@@ -32,6 +32,12 @@ class send_stdhep():
         print("njobs=",self.njobs)
 
         stdhepdir=self.para.stdhep_dir
+        # From winter2023 onwards, the stdhep files are store in stdehp/prodTag or stdhep/prodTag/training
+        if not( 'spring2021' in self.version or 'pre_fall2022' in self.version or 'dev' in self.version ):
+            prodtag = self.version.replace("_training","")
+            stdhepdir=stdhepdir+"/%s/"%(prodtag)
+        if self.typestdhep == 'wzp6' and self.training:
+            stdhepdir = stdhepdir + "training/"
         print("stdhepdir =",stdhepdir)
         gpdir=self.para.gp_dir
 
@@ -45,12 +51,23 @@ class send_stdhep():
 
 
         if not self.islocal:
-             yamldir = '%s/stdhep/%s'%(self.para.yamldir,self.process)
+             yamldir = '%s/stdhep/%s'%(self.para.yamldir,self.process)    # for pre-winter2023 tags
+             if self.training:
+                  yamldir = '%s/stdhep/training/%s'%(self.para.yamldir,self.process)
+             if not( 'spring2021' in self.version or 'pre_fall2022' in self.version or 'dev' in self.version ):   # winter2023 and later:
+                  prodtag = self.version.replace("_training","")
+                  yamldir = '%s/stdhep/%s/%s'%(self.para.yamldir,prodtag,self.process)
+                  if self.training:
+                      yamldir = '%s/stdhep/%s/training/%s'%(self.para.yamldir,prodtag,self.process)
+             print("yamldir = ",yamldir)
              if not ut.dir_exist(yamldir):
                  os.system("mkdir -p %s"%yamldir)
 
         if self.typestdhep == 'wzp6':
-            whizardcard='%s%s.sin'%(self.para.whizardcards_dir, 'v2.8.5/'+self.process)     # Whizard 2.8.5, with Pythia6 interface
+            whizardcard='%s%s.sin'%(self.para.whizardcards_dir, 'v3.0.3/'+self.process)     # Whizard 2.8.5, with Pythia6 interface
+            if 'spring2021' in self.version or 'pre_fall2022' in self.version or 'dev' in self.version:
+                whizardcard='%s%s.sin'%(self.para.whizardcards_dir, 'v2.8.5/'+self.process)     # Whizard 2.8.5, with Pythia6 interface
+	  
 
         whizardcard=whizardcard.replace('_VERSION_',self.version)
         if ut.file_exist(whizardcard)==False:

--- a/config/param_FCCee.py
+++ b/config/param_FCCee.py
@@ -438,13 +438,15 @@ gridpacklist = {
     'wzp6_ee_ee_Mee_30_150_ecm365':['ee (s and t), ecm=365 GeV','30 < Mee < 150 GeV, 15 < theta < 165 deg','','1.53','1.0','1.0'],
 
 
+   # samples for developing flavour tagging algorithms - xsection is not filled
 
-
-
-
-
-
-
+    'wzp6_ee_nunuH_Hbb_ecm240':['ee -> Z(numu numu) H,  ecm=240 GeV','H to bb','','1','1.0','1.0'],
+    'wzp6_ee_nunuH_Hcc_ecm240':['ee -> Z(numu numu) H,  ecm=240 GeV','H to cc','','1','1.0','1.0'],
+    'wzp6_ee_nunuH_Hss_ecm240':['ee -> Z(numu numu) H,  ecm=240 GeV','H to ss','','1','1.0','1.0'],
+    'wzp6_ee_nunuH_Hgg_ecm240':['ee -> Z(numu numu) H,  ecm=240 GeV','H to gg','','1','1.0','1.0'],
+    'wzp6_ee_nunuH_Huu_ecm240':['ee -> Z(numu numu) H,  ecm=240 GeV','H to uu','','1','1.0','1.0'],
+    'wzp6_ee_nunuH_Hdd_ecm240':['ee -> Z(numu numu) H,  ecm=240 GeV','H to dd','','1','1.0','1.0'],
+    'wzp6_ee_nunuH_Htautau_ecm240':['ee -> Z(numu numu) H,  ecm=240 GeV','H to tautau','','1','1.0','1.0'],
 
 
 }

--- a/config/param_FCCee.py
+++ b/config/param_FCCee.py
@@ -47,7 +47,9 @@ prodTag = {
     'spring2021_training':'/cvmfs/sw.hsf.org/spackages2/key4hep-stack/2021-05-12/x86_64-centos7-gcc8.3.0-opt/iyafnfo5muwvpbxcoa4ygwoxi2smkkwa/setup.sh',
     'dev':'/cvmfs/sw.hsf.org/key4hep/setup.sh' ,
     'pre_fall2022':'/cvmfs/fcc.cern.ch/sw/latest/setup.sh',
-    'pre_fall2022_training':'/cvmfs/fcc.cern.ch/sw/latest/setup.sh'
+    'pre_fall2022_training':'/cvmfs/fcc.cern.ch/sw/latest/setup.sh',
+    'winter2023':'/cvmfs/fcc.cern.ch/sw/latest/setup.sh',
+    'winter2023_training':'/cvmfs/fcc.cern.ch/sw/latest/setup.sh',
 }
 
 defaultstack='/cvmfs/fcc.cern.ch/sw/latest/setup.sh'

--- a/init.sh
+++ b/init.sh
@@ -1,6 +1,6 @@
 #source /cvmfs/sw.hsf.org/spackages2/key4hep-stack/2021-04-30/x86_64-centos7-gcc8.3.0-opt/t5gcd6ltt2ikybap2ndoztsg5uyorxzg/setup.sh
-#source /cvmfs/sw.hsf.org/key4hep/setup.sh
-source /cvmfs/sw.hsf.org/spackages2/key4hep-stack/2021-05-12/x86_64-centos7-gcc8.3.0-opt/iyafnfo5muwvpbxcoa4ygwoxi2smkkwa/setup.sh
+source /cvmfs/sw.hsf.org/key4hep/setup.sh
+#source /cvmfs/sw.hsf.org/spackages2/key4hep-stack/2021-05-12/x86_64-centos7-gcc8.3.0-opt/iyafnfo5muwvpbxcoa4ygwoxi2smkkwa/setup.sh
 #spack load --first k4simdelphes build_type=Release ^evtgen+photos
 
 


### PR DESCRIPTION
    Updates for the winter2023 campaign.
    
    - read the Whizard cards from the v3.0.3 directory in FCC-config, since we use this
      new version now
    - stdhep files are now written in stdhep/winter2023, or in stdhep/winter2023/training.
      the path of the yaml directory is also updated.
    - backward compatibility is ensured: when running the scripts for the older prodtags (spring2021,
      prefall2022), one pick up the cards in the proper dir (v2.8.5) and write the files in
      the same place as before.
    
    - also ported some updates needed when one produces whizard samples in a "training" campaign.
