### PR TITLE
Add a few processes in param_FCCee.py

### DIFF
--- a/bin/send_p8.py
+++ b/bin/send_p8.py
@@ -114,9 +114,10 @@ class send_p8():
             frun.write('source %s\n'%(self.para.prodTag[self.version]))
             #frun.write('source /cvmfs/sw.hsf.org/contrib/spack/share/spack/setup-env.sh\n')
             #frun.write('spack load --first k4simdelphes build_type=Release ^evtgen+photos\n')
-            
-            frun.write('mkdir job%s_%s\n'%(uid,self.process))
-            frun.write('cd job%s_%s\n'%(uid,self.process))
+
+            proc_trunc = self.process[:37] + ( self.process[37:] and 'More')            
+            frun.write('mkdir job%s_%s\n'%(uid,proc_trunc))
+            frun.write('cd job%s_%s\n'%(uid,proc_trunc))
             frun.write('export EOS_MGM_URL=\"root://eospublic.cern.ch\"\n')
             if self.islocal==False:
                 frun.write('mkdir -p %s/%s\n'%(outdir,self.process))
@@ -214,7 +215,7 @@ class send_p8():
             #if ut.file_exist(outfile)==False:
             frun.write('python /afs/cern.ch/work/f/fccsw/public/FCCutils/eoscopy.py events_%s.root %s\n'%(uid,outfile))
             frun.write('cd ..\n')
-            frun.write('rm -rf job%s_%s\n'%(uid,self.process))
+            frun.write('rm -rf job%s_%s\n'%(uid,proc_trunc))
             frun.close()
 
             if self.islsf==True :

--- a/config/param_FCCee.py
+++ b/config/param_FCCee.py
@@ -296,9 +296,11 @@ pythialist={
     'p8_ee_Zbb_ecm91_EvtGen_Bd2DsDsKstarDs2pipipipi0pi0':['Z/Gamma* ecm=91.188GeV to bb','B0 -> Ds+ Ds- K*0, K*0 forced to K+ pi-, Ds forced to pipipipipi0','','1','1.0','1.0'],
     'p8_ee_Zbb_ecm91_EvtGen_Bd2DsDsKstarDs2pipipipi0pi0v2':['Z/Gamma* ecm=91.188GeV to bb','B0 -> (Ds+ ->  (eta0 / omega0 -> pi+ pi- pi0) pi+ pi0) (Ds- -> (eta0 / omega0 -> pi+ pi- pi0)  pi- pi0) (K*0 -> K+ pi-)','','1','1.0','1.0'],
     'p8_ee_Zbb_ecm91_EvtGen_Bd2DsKstarTauNuDs2TauNu':['Z/Gamma* ecm=91.188GeV to bb','B0 -> Ds K*0 tau nu, K*0 forced to K+ pi-, Ds forced to tau nu','','1','1.0','1.0'],
-    'p8_ee_Zbb_ecm91_EvtGen_Bd2DsDsKstarDs2TaunuDs2pipipipi0v2':['Z/Gamma* ecm=91.188GeV to bb','B0 -> Ds Ds K*0, K*0 forced to K+ pi-, Ds+ forced to tau nu, Ds- forced to omega/eta pi+','','1','1.0','1.0'],
+    'p8_ee_Zbb_ecm91_EvtGen_Bd2DsDsKstarDs2TaunuDs2pipipipi0v2':['Z/Gamma* ecm=91.188GeV to bb','B0 -> Ds Ds K*0, K*0 forced to K+ pi-, Ds+ forced to tau nu, Ds- forced to omega/eta pi-','','1','1.0','1.0'],
+    'p8_ee_Zbb_ecm91_EvtGen_Bd2DsDsKstarDs2TaunuDs2pipipipi0v2ChargeConjugation':['Z/Gamma* ecm=91.188GeV to bb','B0 -> Ds Ds K*0, K*0 forced to K+ pi-, Ds- forced to tau nu, Ds+ forced to omega/eta pi+','','1','1.0','1.0'],
     'p8_ee_Zbb_ecm91_EvtGen_Bd2DsstarDsKstarDs2TaunuDsstar2Dsgamma':['Z/Gamma* ecm=91.188GeV to bb','B0 -> Ds*+ Ds- K*0, K*0 forced to K+ pi-, Ds forced to tau nu, D*s+ forced in Ds gamma','','1','1.0','1.0'],
     'p8_ee_Zbb_ecm91_EvtGen_Bd2DsDsKstarDs2TaunuDs2pipipipi0pi0':['Z/Gamma* ecm=91.188GeV to bb','B0 -> Ds+ Ds- K*0, K*0 forced to K+ pi-, Ds+ forced to tau nu, Ds- forced to multi pions','','1','1.0','1.0'],
+    'p8_ee_Zbb_ecm91_EvtGen_Bd2DsDsKstarDs2TaunuDs2pipipipi0pi0ChargeConjugation':['Z/Gamma* ecm=91.188GeV to bb','B0 -> Ds+ Ds- K*0, K*0 forced to K+ pi-, Ds- forced to tau nu, Ds+ forced to multi pions','','1','1.0','1.0'],
     'p8_ee_Zbb_ecm91_EvtGen_Bd2DsstarDsKstarDs2PiPiPiPi0Pi0Dsstar2Dsgamma':['Z/Gamma* ecm=91.188GeV to bb','B0 -> Ds*+ Ds- K*0, K*0 forced to K+ pi-, Ds*+ forced to Ds+ and gamma, and both Ds+ and Ds- forced to multi pions','','1','1.0','1.0'],
     'p8_ee_Zbb_ecm91_EvtGen_Bd2DsstarKstarTauNuDs2pipipipi0pi0':['Z/Gamma* ecm=91.188GeV to bb','B0 -> Ds*+ tau- K*0, K*0 forced to K+ pi-, Ds* forced to Ds gamma, and Ds forced to multi pions','','1','1.0','1.0'],
 #Bu = 0.307 * 0.43 = 0.13201

--- a/config/param_FCCee.py
+++ b/config/param_FCCee.py
@@ -296,7 +296,11 @@ pythialist={
     'p8_ee_Zbb_ecm91_EvtGen_Bd2DsDsKstarDs2pipipipi0pi0':['Z/Gamma* ecm=91.188GeV to bb','B0 -> Ds+ Ds- K*0, K*0 forced to K+ pi-, Ds forced to pipipipipi0','','1','1.0','1.0'],
     'p8_ee_Zbb_ecm91_EvtGen_Bd2DsDsKstarDs2pipipipi0pi0v2':['Z/Gamma* ecm=91.188GeV to bb','B0 -> (Ds+ ->  (eta0 / omega0 -> pi+ pi- pi0) pi+ pi0) (Ds- -> (eta0 / omega0 -> pi+ pi- pi0)  pi- pi0) (K*0 -> K+ pi-)','','1','1.0','1.0'],
     'p8_ee_Zbb_ecm91_EvtGen_Bd2DsKstarTauNuDs2TauNu':['Z/Gamma* ecm=91.188GeV to bb','B0 -> Ds K*0 tau nu, K*0 forced to K+ pi-, Ds forced to tau nu','','1','1.0','1.0'],
+    'p8_ee_Zbb_ecm91_EvtGen_Bd2DsDsKstarDs2TaunuDs2pipipipi0v2':['Z/Gamma* ecm=91.188GeV to bb','B0 -> Ds Ds K*0, K*0 forced to K+ pi-, Ds+ forced to tau nu, Ds- forced to omega/eta pi+','','1','1.0','1.0'],
     'p8_ee_Zbb_ecm91_EvtGen_Bd2DsstarDsKstarDs2TaunuDsstar2Dsgamma':['Z/Gamma* ecm=91.188GeV to bb','B0 -> Ds*+ Ds- K*0, K*0 forced to K+ pi-, Ds forced to tau nu, D*s+ forced in Ds gamma','','1','1.0','1.0'],
+    'p8_ee_Zbb_ecm91_EvtGen_Bd2DsDsKstarDs2TaunuDs2pipipipi0pi0':['Z/Gamma* ecm=91.188GeV to bb','B0 -> Ds+ Ds- K*0, K*0 forced to K+ pi-, Ds+ forced to tau nu, Ds- forced to multi pions','','1','1.0','1.0'],
+    'p8_ee_Zbb_ecm91_EvtGen_Bd2DsstarDsKstarDs2PiPiPiPi0Pi0Dsstar2Dsgamma':['Z/Gamma* ecm=91.188GeV to bb','B0 -> Ds*+ Ds- K*0, K*0 forced to K+ pi-, Ds*+ forced to Ds+ and gamma, and both Ds+ and Ds- forced to multi pions','','1','1.0','1.0'],
+    'p8_ee_Zbb_ecm91_EvtGen_Bd2DsstarKstarTauNuDs2pipipipi0pi0':['Z/Gamma* ecm=91.188GeV to bb','B0 -> Ds*+ tau- K*0, K*0 forced to K+ pi-, Ds* forced to Ds gamma, and Ds forced to multi pions','','1','1.0','1.0'],
 #Bu = 0.307 * 0.43 = 0.13201
 #Bd = 0.242 * 0.43 = 0.10406
 #Bs = 0.243 * 0.096 = 0.023328


### PR DESCRIPTION
Add a few processes for Bd to Ds Ds K* decays to the process list.
Also, truncate the process name for the intermediate `mkdir` steps on condor machines, to avoid `argument too long` problems. This does not change anything on the use side.