### PR TITLE
Using event counting directory in /tmp instead of on AFS

### DIFF
--- a/bin/run.py
+++ b/bin/run.py
@@ -298,8 +298,8 @@ if __name__=="__main__":
 
         elif args.reco:
             print('create web page for reco version %s' % version)
-            webpage=para.delphes_web.replace('VERSION',version).replace('DETECTOR',detector)
-            printdic=prt.printer(yamldir, webpage, True, False, para, detector, version)
+            webpage = para.delphes_web.replace('VERSION', version).replace('DETECTOR', detector)
+            printdic = prt.printer(yamldir, webpage, True, False, para, detector, version)
             printdic.run()
 
     elif args.remove:

--- a/common/printer.py
+++ b/common/printer.py
@@ -40,6 +40,7 @@ class printer():
 
         #ldir=[x[0] for x in os.walk(self.indir)]
         ldir=next(os.walk(self.indir))[1]
+        print(ldir)
 
 #        checkfiles=''
 #        if self.isLHE: checkfiles='%s/files.yaml'%(self.para.lhe_dir)
@@ -94,15 +95,15 @@ class printer():
                     br = self.para.branching_ratios[dec]
                     decay = dec
             if decay != '':
-                print ('decay---------- ',decay,' ------- br ',br)
+                print ('decay---------- ', decay, ' ------- br ', br)
                 decstr = '_{}'.format(decay)
 
             ispythiaonly=False
 
-            print ('proc ================================= ',proc)
+            print ('proc ================================= ', proc)
             
             try: 
-                teststring=self.para.gridpacklist[proc][0]
+                teststring = self.para.gridpacklist[proc][0]
             except IOError as e:
                 print ("I/O error({0}): {1}".format(e.errno, e.strerror))
             except ValueError:
@@ -163,8 +164,11 @@ class printer():
             nfileseos=0
 #            nfileseos=tmpcheck[proc]['neos']
             if self.isLHE:
-                if os.path.isdir('%s%s'%(self.para.lhe_dir,proc)):
-                    nfileseos=len(os.listdir('%s%s'%(self.para.lhe_dir,proc)))
+                if os.path.isdir('%s%s' % (self.para.lhe_dir, proc)):
+                    file_list_eos = os.listdir('%s%s' % (self.para.lhe_dir, proc))
+                    file_list_eos = [fname for fname in file_list_eos
+                                           if fname.endswith('.lhe.gz')]
+                    nfileseos = len(file_list_eos)
             else:                    
                 if os.path.isdir('%s%s/%s/%s'%(self.para.delphes_dir,self.version,self.detector,process)): 
                     print ('%s%s/%s/%s'%(self.para.delphes_dir,self.version,self.detector,process))

--- a/config/param_FCChh.py
+++ b/config/param_FCChh.py
@@ -975,7 +975,7 @@ gridpacklist = {
 'mg_pp_mumu012j_mhcut_5f':['mu+ mu- + 0/1/2 jets','50 < m(mumu) < 200','','1.4e+04','1.0','0.753'],
 'mg_pp_lla01j_mhcut_5f':['l+ l- gamma + 0/1 jets','50 < m(lla) < 200','','639.1','1.0','0.78'],
 'mg_gg_aa01j_mhcut_5f':['gluon fusion di-photon + 0/1 jets','50 < m(aa) < 200','','484.2','1.0','0.592'],
-'mg_pp_aa012j_mhcut_5f':['di-photon + 0/1/2 jets','50 < m(aa) < 200','','1530','1.0','1.0'],
+'mg_pp_aa012j_mhcut_5f':['di-photon + 0/1/2 jets','50 < m(aa) < 200','','1530','1.0','0.399'],
 'mg_pp_llll01j_mhcut_5f':['4l + 0/1 jets','50 < m(4l) < 200','','0.1517','1.0','0.813'],
 'mg_pp_aa012j_mhcut_5f_HT_0_100':['di-photon + 0/1/2 jets','0 < HT < 100','xqcut = 30, qCut = 40','116.8','2.0','0.656'],
 'mg_pp_aa012j_mhcut_5f_HT_100_300':['di-photon + 0/1/2 jets','100 < HT < 300','xqcut = 30, qCut = 40','61.58','2.0','0.591'],
@@ -1341,7 +1341,7 @@ gridpacklist = {
 'mg_pp_vbs_wwss_kw_150_LL':['','inclusive','','0.1052','1.0','1.0'],
 
 # bbtautau
-'mg_pp_bbtata_QCDQED':['','inclusive','','75.61','1.0','1.0'],
+'mg_pp_bbtata_QCDQED':['','inclusive','','75.61','1.0','1.006'],
 'mg_pp_bbtata_QED':['','inclusive','','0.5519','1.0','1.0'],
 
 # bbjj

--- a/scripts/cronrun_RECO_FCChh.sh
+++ b/scripts/cronrun_RECO_FCChh.sh
@@ -1,9 +1,9 @@
 PROD_TAG="${1}"
 
-cd /afs/cern.ch/user/f/fccsw/private/EventProducer/ || exit
+cd /afs/cern.ch/user/f/fccsw/private/EventProducer/ || exit 1
 source ./init.sh
 LOGFILE="${EVENTPRODUCER}/log/cronrun_RECO_FCChh.log"
-echo "" > "${LOGFILE}"
+echo "`date`  INFO: Cron run started." > "${LOGFILE}"
 
 SYNCLOCK="${EVENTPRODUCER}/.sync.lock"
 # Making sure the last sync went OK and there is no .sync.lock file left


### PR DESCRIPTION
This change results in improved speed for the event counting and less false filesystem error messages.