### PR TITLE
Adjustments for the FCC-hh v06 campaign

### DIFF
--- a/common/makeSampleList.py
+++ b/common/makeSampleList.py
@@ -21,6 +21,7 @@ class MakeSampleList:
         for fpath in self.para.procList:
             filepath = fpath.replace('VERSION', version)
             filepath = filepath.replace('DETECTOR', detector)
+            filepath = filepath.replace('-.', '.')
             self.outpaths.append(filepath)
         self.version = version
         self.detector = detector
@@ -286,12 +287,17 @@ class MakeSampleList:
         # strip last comma and check the validity of JSON
         with open(f'tmp_{uid}.json', 'r', encoding='utf-8') as infile:
             data = infile.read()
-            proc_dict_string = data[:-2] + '\n}'
+            if len(data) > 2:
+                proc_dict_string = data[:-2]
+            else:
+                proc_dict_string = data
+            proc_dict_string += '\n}'
 
             try:
                 proc_dict_json = json.loads(proc_dict_string)
             except json.decoder.JSONDecodeError:
                 print('ERROR: Resulting procDict is not valid JSON!')
+                print('       Aborting...')
                 sys.exit(3)
 
         # save procDict to file(s)

--- a/common/makeSampleList.py
+++ b/common/makeSampleList.py
@@ -21,7 +21,7 @@ class MakeSampleList:
         for fpath in self.para.procList:
             filepath = fpath.replace('VERSION', version)
             filepath = filepath.replace('DETECTOR', detector)
-            filepath = filepath.replace('-.', '.')
+            filepath = filepath.replace('_.', '.')
             self.outpaths.append(filepath)
         self.version = version
         self.detector = detector

--- a/config/param_FCChh.py
+++ b/config/param_FCChh.py
@@ -10,15 +10,15 @@ delphes_stat = "/eos/experiment/fcc/www/data/FCChh/statdelphesVERSION.html"
 
 # web
 lhe_web = "/eos/experiment/fcc/www/data/FCChh/LHEevents.txt"
-delphes_web = "/eos/experiment/fcc/www/data/FCChh/Delphesevents_VERSION.txt"
+delphes_web = "/eos/experiment/fcc/www/data/FCChh/Delphesevents_VERSION_DETECTOR.txt"
 
 # yaml directory
 yamldir = '/afs/cern.ch/work/f/fccsw/public/FCCDicts/yaml/FCChh/'
 
 # proc lists
 procList = [
-     '/afs/cern.ch/work/f/fccsw/public/FCCDicts/FCChh_procDict_VERSION.json',
-     '/eos/experiment/fcc/www/data/FCCDicts/FCChh_procDict_VERSION.json'
+     '/afs/cern.ch/work/f/fccsw/public/FCCDicts/FCChh_procDict_VERSION_DETECTOR.json',
+     '/eos/experiment/fcc/www/data/FCCDicts/FCChh_procDict_VERSION_DETECTOR.json'
 ]
 
 ##eos directory for MG5@MCatNLO gridpacks
@@ -1081,22 +1081,22 @@ gridpacklist = {
 'mg_pp_aa012j_mhcut_5f_HT_700_900':['di-photon + 0/1/2 jets','700 < HT < 900','xqcut = 30, qCut = 40','0.4198','2.0','0.872'],
 'mg_pp_aa012j_mhcut_5f_HT_900_1100':['di-photon + 0/1/2 jets','900 < HT < 1100','xqcut = 30, qCut = 40','0.1834','2.0','0.896'],
 'mg_pp_aa012j_mhcut_5f_HT_1100_100000':['di-photon + 0/1/2 jets','1100 < HT < 100000','xqcut = 30, qCut = 40','0.3637','2.0','0.931'],
-'mg_pp_mumu012j_mhcut_5f_HT_0_100':['mu+ mu- + 0/1/2 jets','0 < HT < 100','xqcut = 30, qCut = 40','382.9','1.20','0.694'],
-'mg_pp_mumu012j_mhcut_5f_HT_100_300':['mu+ mu- + 0/1/2 jets','100 < HT < 300','xqcut = 30, qCut = 40','44.08','1.20','0.339'],
-'mg_pp_mumu012j_mhcut_5f_HT_300_500':['mu+ mu- + 0/1/2 jets','300 < HT < 500','xqcut = 30, qCut = 40','4.723','1.20','0.221'],
-'mg_pp_mumu012j_mhcut_5f_HT_500_700':['mu+ mu- + 0/1/2 jets','500 < HT < 700','xqcut = 30, qCut = 40','1.14','1.20','0.148'],
-'mg_pp_mumu012j_mhcut_5f_HT_700_900':['mu+ mu- + 0/1/2 jets','700 < HT < 900','xqcut = 30, qCut = 40','0.3945','1.20','0.115'],
-'mg_pp_mumu012j_mhcut_5f_HT_900_1100':['mu+ mu- + 0/1/2 jets','900 < HT < 1100','xqcut = 30, qCut = 40','0.1691','1.20','0.09'],
-'mg_pp_mumu012j_mhcut_5f_HT_1100_100000':['mu+ mu- + 0/1/2 jets','1100 < HT < 100000','xqcut = 30, qCut = 40','0.2093','1.20','0.058'],
+'mg_pp_mumu012j_mhcut_5f_HT_0_100':['mu+ mu- + 0/1/2 jets','0 < HT < 100','xqcut = 30, qCut = 40','382.9','1.20','1.0'],
+'mg_pp_mumu012j_mhcut_5f_HT_100_300':['mu+ mu- + 0/1/2 jets','100 < HT < 300','xqcut = 30, qCut = 40','44.08','1.20','1.0'],
+'mg_pp_mumu012j_mhcut_5f_HT_300_500':['mu+ mu- + 0/1/2 jets','300 < HT < 500','xqcut = 30, qCut = 40','4.723','1.20','1.0'],
+'mg_pp_mumu012j_mhcut_5f_HT_500_700':['mu+ mu- + 0/1/2 jets','500 < HT < 700','xqcut = 30, qCut = 40','1.14','1.20','0.983'],
+'mg_pp_mumu012j_mhcut_5f_HT_700_900':['mu+ mu- + 0/1/2 jets','700 < HT < 900','xqcut = 30, qCut = 40','0.3945','1.20','0.998'],
+'mg_pp_mumu012j_mhcut_5f_HT_900_1100':['mu+ mu- + 0/1/2 jets','900 < HT < 1100','xqcut = 30, qCut = 40','0.1691','1.20','0.993'],
+'mg_pp_mumu012j_mhcut_5f_HT_1100_100000':['mu+ mu- + 0/1/2 jets','1100 < HT < 100000','xqcut = 30, qCut = 40','0.2093','1.20','0.98'],
 'mg_pp_lla01j_mhcut_5f_HT_0_100':['l+ l- gamma + 0/1 jets','0 < HT < 100','xqcut = 30, qCut = 40','39.52','1.50','0.75'],
 'mg_pp_lla01j_mhcut_5f_HT_100_300':['l+ l- gamma + 0/1 jets','100 < HT < 300','xqcut = 30, qCut = 40','1.326','1.50','0.486'],
 'mg_pp_lla01j_mhcut_5f_HT_300_500':['l+ l- gamma + 0/1 jets','300 < HT < 500','xqcut = 30, qCut = 40','0.004548','1.50','0.245'],
 'mg_pp_lla01j_mhcut_5f_HT_300_100000':['l+ l- gamma + 0/1 jets','300 < HT < 100000','xqcut = 30, qCut = 40','0.08149','1.50','0.234'],
 'mg_pp_lla01j_mhcut_5f_HT_500_100000':['l+ l- gamma + 0/1 jets','500 < HT < 100000','xqcut = 30, qCut = 40','0.002727','1.50','0.162'],
-'mg_pp_llll01j_mhcut_5f_HT_0_200':['Z/gamma* Z/gamma* to 4l + 0/1 jets','0 < HT < 200','xqcut = 40, qCut = 60','0.04957','1.60','0.808'],
-'mg_pp_llll01j_mhcut_5f_HT_200_500':['Z/gamma* Z/gamma* to 4l + 0/1 jets','200 < HT < 500','xqcut = 40, qCut = 60','0.0002159','1.60','0.937'],
-'mg_pp_llll01j_mhcut_5f_HT_500_1100':['Z/gamma* Z/gamma* to 4l + 0/1 jets','500 < HT < 1100','xqcut = 40, qCut = 60','5.573e-06','1.60','0.949'],
-'mg_pp_llll01j_mhcut_5f_HT_1100_100000':['Z/gamma* Z/gamma* to 4l + 0/1 jets','1100 < HT < 100000','xqcut = 40, qCut = 60','1.361e-07','1.60','0.972'],
+'mg_pp_llll01j_mhcut_5f_HT_0_200':['Z/gamma* Z/gamma* to 4l + 0/1 jets','0 < HT < 200','xqcut = 40, qCut = 60','0.04957','1.60','1.0'],
+'mg_pp_llll01j_mhcut_5f_HT_200_500':['Z/gamma* Z/gamma* to 4l + 0/1 jets','200 < HT < 500','xqcut = 40, qCut = 60','0.0002159','1.60','1.0'],
+'mg_pp_llll01j_mhcut_5f_HT_500_1100':['Z/gamma* Z/gamma* to 4l + 0/1 jets','500 < HT < 1100','xqcut = 40, qCut = 60','5.573e-06','1.60','1.0'],
+'mg_pp_llll01j_mhcut_5f_HT_1100_100000':['Z/gamma* Z/gamma* to 4l + 0/1 jets','1100 < HT < 100000','xqcut = 40, qCut = 60','1.361e-07','1.60','1.0'],
 'mg_gg_aa01j_mhcut_5f_HT_0_200':['gluon fusion di-photon + 0/1 jets','0 < HT < 200','xqcut = 20, qCut = 30','60.21','2.0','0.408'],
 'mg_gg_aa01j_mhcut_5f_HT_200_500':['gluon fusion di-photon + 0/1 jets','200 < HT < 500','xqcut = 20, qCut = 30','0.026','2.0','0.915'],
 'mg_gg_aa01j_mhcut_5f_HT_200_100000':['gluon fusion di-photon + 0/1 jets','200 < HT < 100000','xqcut = 20, qCut = 30','0.02618','2.0','0.917'],

--- a/scripts/cronrun_RECO_FCChh.sh
+++ b/scripts/cronrun_RECO_FCChh.sh
@@ -1,26 +1,28 @@
 PROD_TAG="${1}"
+DETECTOR="${2}"
+set --
 
 cd /afs/cern.ch/user/f/fccsw/private/EventProducer/ || exit 1
+
 source ./init.sh
-LOGFILE="${EVENTPRODUCER}/log/cronrun_RECO_FCChh.log"
+LOGFILE="${EVENTPRODUCER}/log/cronrun_RECO_FCChh_${PROD_TAG}_${DETECTOR}.log"
 echo "`date`  INFO: Cron run started." > "${LOGFILE}"
 
-SYNCLOCK="${EVENTPRODUCER}/.sync.lock"
 # Making sure the last sync went OK and there is no .sync.lock file left
-if [ -f "${SYNCLOCK}" ]; then
+if [ -f "${EVENTPRODUCER}/.sync.lock" ]; then
   echo "`date`  WARNING: Encountered git sync lock. Aborting..." >> "${LOGFILE}"
 
   exit 3
 fi
 
-python bin/run.py --FCChh --reco --checkeos --prodtag "${PROD_TAG}" --detector "" > /dev/null
-python bin/run.py --FCChh --reco --check --prodtag "${PROD_TAG}" --detector "" > /dev/null
-python bin/run.py --FCChh --reco --merge --prodtag "${PROD_TAG}" --detector "" > /dev/null
-python bin/run.py --FCChh --reco --clean --prodtag "${PROD_TAG}" --detector "" > /dev/null
-python bin/run.py --FCChh --reco --cleanold --prodtag "${PROD_TAG}" --detector "" > /dev/null
-python bin/run.py --FCChh --reco --merge --prodtag "${PROD_TAG}" --detector "" > /dev/null
-python bin/run.py --FCChh --reco --web --prodtag "${PROD_TAG}" --detector "" > /dev/null
-python bin/run.py --FCChh --reco --sample --prodtag "${PROD_TAG}" --detector "" > /dev/null
+python bin/run.py --FCChh --reco --checkeos --prodtag "${PROD_TAG}" --detector "${DETECTOR}" >> "${LOGFILE}" || exit 1
+python bin/run.py --FCChh --reco --check --prodtag "${PROD_TAG}" --detector "${DETECTOR}" >> "${LOGFILE}" || exit 1
+python bin/run.py --FCChh --reco --merge --prodtag "${PROD_TAG}" --detector "${DETECTOR}" >> "${LOGFILE}" || exit 1
+python bin/run.py --FCChh --reco --clean --prodtag "${PROD_TAG}" --detector "${DETECTOR}" >> "${LOGFILE}" || exit 1
+python bin/run.py --FCChh --reco --cleanold --prodtag "${PROD_TAG}" --detector "${DETECTOR}" >> "${LOGFILE}" || exit 1
+python bin/run.py --FCChh --reco --merge --prodtag "${PROD_TAG}" --detector "${DETECTOR}" >> "${LOGFILE}" || exit 1
+python bin/run.py --FCChh --reco --web --prodtag "${PROD_TAG}" --detector "${DETECTOR}" >> "${LOGFILE}" || exit 1
+python bin/run.py --FCChh --reco --sample --prodtag "${PROD_TAG}" --detector "${DETECTOR}" >> "${LOGFILE}" || exit 1
 
 mkdir -p "${EVENTPRODUCER}/log"
 echo "`date`  INFO: Cron run finished." >> "${LOGFILE}"


### PR DESCRIPTION
* Campaign `fcc_v06` scenario `I` produces empty procDict JSON.
* Adjusted output files with DETECTOR template mark.
* Several processes are clashing, example:
  * Process `mg_pp_mumu012j_mhcut_5f_HT_0_100` is in `fcc_v02` and also in `fcc_v06` scenario `II`.
* Full log of running EventProducer in campaign `v06` for scenario `I` and `II` is [here](https://github.com/user-attachments/files/17980211/fcc_v06_log.txt)
